### PR TITLE
Timeout issue resolved

### DIFF
--- a/src/lss.py
+++ b/src/lss.py
@@ -19,7 +19,7 @@ import lss_const as lssc
 ### Class functions
 def initBus(portName, portBaud):
 	LSS.bus = serial.Serial(portName, portBaud)
-	LSS.bus.timeout = 0.1
+	LSS.bus.timeout = 2 #Increased to avoid loosing late replies
 
 def closeBus():
 	if LSS.bus is not None:
@@ -48,7 +48,7 @@ def genericRead_Blocking_int(id, cmd):
 			if(c.decode("utf-8") == ""):
 				break
 		# Get packet
-		data = LSS.bus.read_until(lssc.LSS_CommandEnd)
+		data = LSS.bus.read_until(lssc.LSS_CommandEnd.encode('utf-8')) #Otherwise (without ".encode('utf-8')") the received LSS_CommandEnd is not recognized by read_until, making it wait until timeout.
 		# Parse packet
 		matches = re.match("(\d{1,3})([A-Z]{1,4})(-?\d{1,18})", data.decode("utf-8"), re.I)
 		# Check if matches are found
@@ -86,7 +86,7 @@ def genericRead_Blocking_str(id, cmd, numChars):
 			if(c.decode("utf-8") == ""):
 				break
 		# Get packet
-		data = LSS.bus.read_until(lssc.LSS_CommandEnd)
+		data = LSS.bus.read_until(lssc.LSS_CommandEnd.encode('utf-8')) #Otherwise (without ".encode('utf-8')") the received LSS_CommandEnd is not recognized by read_until, making it wait until timeout.
 		data = (data[:-1])
 		# Parse packet
 		matches = re.match("(\d{1,3})([A-Z]{1,4})(.{" + str(numChars) + "})", data.decode("utf-8"), re.I)

--- a/src/lss.py
+++ b/src/lss.py
@@ -19,7 +19,7 @@ import lss_const as lssc
 ### Class functions
 def initBus(portName, portBaud):
 	LSS.bus = serial.Serial(portName, portBaud)
-	LSS.bus.timeout = 2 #Increased to avoid loosing late replies
+	LSS.bus.timeout = 0.1
 
 def closeBus():
 	if LSS.bus is not None:


### PR DESCRIPTION
In lss.py, in the read functions, LSS.bus.read_until waits until the timeout, slowing reading down significantly. This can be fixed by adding .encode('utf-8') to lssc.LSS_CommandEnd:

data = LSS.bus.read_until(lssc.LSS_CommandEnd.encode('utf-8'))

The problem is, that the whole communication from and to the servos seems to be UTF8-coded, which is respected in the code. But in the read_until statement, the "lssc.LSS_CommandEnd" is ASCII-coded, so it is never found. This way, read_until always waits until the timeout occurs. That is not noticed so easily as the timeout is currently set to 0.1s. If you set it to 1 or more seconds, you can see that the response always takes exactly as long as the timeout is set. On the other hand, before the timeout, the other data that is received before lssc.LSS_CommandEnd is already enough to interpret the answer, so the asked for values are correctly received.

The solution is to use lssc.LSS_CommandEnd.encode('utf-8') to convert also this command end char to UTF8, so it is correctly found way before the timeout. To test this, you can make this change and set the timeout a lot higher, the communication response will still be a lot quicker.